### PR TITLE
Major improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 /.coverage*
 /htmlcov/
 /dist/
+.tox/

--- a/astypes/__init__.py
+++ b/astypes/__init__.py
@@ -3,8 +3,9 @@
 from ._ass import Ass
 from ._ast import find_node
 from ._handlers import get_type
-from ._type import Type
+from ._type import Type, merge_types
+from ._signature import signature
 
 
 __version__ = '0.2.2'
-__all__ = ['find_node', 'get_type', 'Ass', 'Type']
+__all__ = ['find_node', 'get_type', 'merge_types', 'signature', 'Ass', 'Type']

--- a/astypes/__init__.py
+++ b/astypes/__init__.py
@@ -8,4 +8,4 @@ from ._signature import signature
 
 
 __version__ = '0.2.2'
-__all__ = ['find_node', 'get_type', 'merge_types', 'signature', 'Ass', 'Type']
+__all__ = ['find_node', 'get_type', 'signature', 'Ass', 'Type']

--- a/astypes/_ann_to_type.py
+++ b/astypes/_ann_to_type.py
@@ -1,0 +1,152 @@
+"""
+Adjusted from griffe/src/griffe/agents/nodes.py
+"""
+
+import sys
+import typing as t
+import astroid
+
+from ._type import Type, union
+from ._signature import AstValue
+from ._resolve_qualname import resolve_qualname
+
+def node2dottedname(node: t.Optional[astroid.nodes.NodeNG]) -> t.Optional[t.List[str]]:
+    """
+    Resove expression composed by `astroid.nodes.Attribute` and `astroid.nodes.Name` nodes to a list of names. 
+    :note: Supports variants `AssignAttr` and `AssignName`.
+    """
+    parts = []
+    while isinstance(node, (astroid.nodes.Attribute, astroid.nodes.AssignAttr)):
+        parts.append(node.attrname or '')
+        node = node.expr
+    if isinstance(node, (astroid.nodes.Name, astroid.nodes.AssignName)):
+        parts.append(node.name or '')
+    else:
+        return None
+    parts.reverse()
+    return parts
+
+def node2qualname(node: t.Optional[astroid.nodes.NodeNG]) -> t.Optional[str]:
+    """
+    Resove expression composed by `Attribute` and `Name` nodes to a fuller name
+    """
+    dottedname = node2dottedname(node)
+    if dottedname:
+        return resolve_qualname(node, '.'.join(dottedname))
+    return None
+
+# ==========================================================
+# annotations
+def _get_attribute_annotation(node: astroid.Attribute) -> Type:
+    qualname = node2qualname(node)
+    if qualname:
+        module, _, name = qualname.rpartition('.')
+        return Type.new(name, module=module)
+    else:
+        # the annotation is something like func().Something, not an actual name.
+        return Type.new(node.attrname, module=repr(AstValue(node.expr)))
+
+def _get_binop_annotation(node: astroid.BinOp) -> Type:
+    # support new style unions
+    if node.op == '|':
+        left = get_annotation(node.left)
+        right = get_annotation(node.right)
+        return union(left, right)
+    else:
+        raise KeyError(node.op)
+
+def _get_constant_annotation(node: astroid.Const) -> Type | None: 
+    # TODO unstring annotation before.   
+    return _get_literal_annotation(node)
+
+def _get_ellipsis_annotation(node: astroid.Ellipsis) -> Type:
+    return Type.new('...') 
+
+def _get_literal_annotation(node: astroid.Const) -> str:
+    # special case Ellipsis
+    name = {type(...): lambda _: "..."}.get(type(node.value), repr)(node.value)
+    return Type.new(name)
+
+# Sometimes, software abuse annotations for other stuff, new don't recognize this
+# def _get_keyword_annotation(node: astroid.Keyword) -> Type:
+#     return Type(f"{node.arg}=", get_annotation(node.value))
+
+# List annotation is used for Callables
+# def _get_list_annotation(node: astroid.List) -> Type:
+#     return Type("[", *_join([get_annotation(el) for el in node.elts], ", "), "]")
+
+
+def _get_name_annotation(node: astroid.Name) -> Type:
+    qualname = node2qualname(node)
+    if qualname:
+        module, _, name = qualname.rpartition('.')
+        return Type.new(name, module=module)
+    else:
+        return Type(node.name)
+
+
+def _get_subscript_annotation(node: astroid.Subscript) -> Type:
+    left = get_annotation(node.value)
+    if isinstance(node.slice, astroid.Tuple):
+        args = _get_tuple_annotation(node.slice)
+        left = left.replace(args=args)
+        # _node_annotation_map[astroid.Const] = _get_literal_annotation
+        # subscript = get_annotation(node.slice)
+        # _node_annotation_map[astroid.Const] = _get_constant_annotation
+    else:
+        arg = get_annotation(node.slice)
+        if arg:
+            left = left.replace(args=[arg])    
+    return left
+
+def _get_tuple_annotation(node: astroid.Tuple) -> t.List[Type]:
+    return [get_annotation(el) or Type.new('') for el in node.elts]
+
+
+# def _get_unaryop_annotation(node: astroid.UnaryOp) -> Type:
+#     return Type(get_annotation(node.op), get_annotation(node.operand))
+
+
+# def _get_uadd_annotation(node: astroid.UAdd) -> str:
+#     return "+"
+
+
+# def _get_usub_annotation(node: astroid.USub) -> str:
+#     return "-"
+
+
+_node_annotation_map: dict[Type, t.Callable[[t.Any], Type]] = {
+    astroid.Attribute: _get_attribute_annotation,
+    astroid.BinOp: _get_binop_annotation,
+    astroid.Const: _get_constant_annotation,
+    # astroid.IfExp: _get_ifexp_annotation,
+    # astroid.Invert: _get_invert_annotation,
+    # astroid.Keyword: _get_keyword_annotation,
+    # astroid.List: _get_list_annotation,
+    astroid.Name: _get_name_annotation,
+    astroid.Subscript: _get_subscript_annotation,
+    astroid.Tuple: _get_tuple_annotation,
+    # astroid.UnaryOp: _get_unaryop_annotation,
+    # astroid.UAdd: _get_uadd_annotation,
+    # astroid.USub: _get_usub_annotation,
+}
+
+if sys.version_info < (3, 8):
+    _node_annotation_map[astroid.Ellipsis] = _get_ellipsis_annotation
+
+def _get_annotation(node: astroid.NodeNG) -> Type:
+    return _node_annotation_map[type(node)](node)
+
+
+def get_annotation(node: astroid.NodeNG) -> Type:
+    """Extract a resolvable annotation.
+    Parameters:
+        node: The annotation node.
+    Returns:
+        A string or resovable name or expression.
+    """
+
+    try:
+        return _get_annotation(node)
+    except KeyError:
+        return Type.new('')

--- a/astypes/_ann_to_type.py
+++ b/astypes/_ann_to_type.py
@@ -138,12 +138,12 @@ def _get_annotation(node: astroid.NodeNG) -> Type:
     return _node_annotation_map[type(node)](node)
 
 
-def get_annotation(node: astroid.NodeNG) -> Type:
+def get_annotation(node: astroid.NodeNG | None) -> Type:
     """Extract a resolvable annotation.
     Parameters:
         node: The annotation node.
     Returns:
-        A string or resovable name or expression.
+        A Type instance. Returns the unknown type if we can't make sens of the type annotation.
     """
 
     try:

--- a/astypes/_helpers.py
+++ b/astypes/_helpers.py
@@ -77,7 +77,7 @@ def conv_node_to_type(
         logger.debug('no return type annotation for called function def')
         return None
 
-    # for generics, don't keep it generic
+    # for generics, keep it generic
     if isinstance(node, (ast.Subscript, astroid.Subscript)):
         return conv_node_to_type(mod_name, node.value)
 

--- a/astypes/_helpers.py
+++ b/astypes/_helpers.py
@@ -45,7 +45,7 @@ def get_ret_type_of_fun(
     mod_name: str,
     fun_name: str,
 ) -> Type | None:
-    """For the given module and function name, get return type of the function.
+    """For the given module and function name, get return type of the function from typeshed.
     """
     module = typeshed_client.get_stub_names(mod_name)
     if module is None:
@@ -66,7 +66,9 @@ def conv_node_to_type(
     mod_name: str,
     node: ast.AST | astroid.NodeNG | None,
 ) -> Type | None:
-    """Resolve ast node representing a type annotation into a type.
+    """
+    Resolve ast node representing a type annotation into a type. 
+    Partial implementation.
     """
     import builtins
     import typing
@@ -75,7 +77,7 @@ def conv_node_to_type(
         logger.debug('no return type annotation for called function def')
         return None
 
-    # for generics, keep it generic
+    # for generics, don't keep it generic
     if isinstance(node, (ast.Subscript, astroid.Subscript)):
         return conv_node_to_type(mod_name, node.value)
 

--- a/astypes/_resolve_qualname.py
+++ b/astypes/_resolve_qualname.py
@@ -1,0 +1,96 @@
+
+from typing import  Iterable, Tuple, Union
+import re
+
+import astroid.nodes
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+def resolve_import_alias(name:str, import_names:Iterable[Tuple[str, Union[str,None]]]) -> str:
+    """Resolve a name from an aliased import to its original name.
+    :param name: The potentially aliased name to resolve.
+    :param import_names: The pairs of original names and aliases
+        from the import.
+    :returns: The original name.
+    """
+    resolved_name = name
+
+    for import_name, imported_as in import_names:
+        if import_name == name:
+            break
+        if imported_as == name:
+            resolved_name = import_name
+            break
+
+    return resolved_name
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+def get_full_import_name(import_from:astroid.nodes.ImportFrom, name:str) -> str:
+    """Get the full path of a name from a ``from x import y`` statement.
+    :param import_from: The astroid node to resolve the name of.
+    :param name:
+    :returns: The full import path of the name.
+    """
+    partial_basename = resolve_import_alias(name, import_from.names)
+
+    module_name = import_from.modname
+    if import_from.level:
+        module = import_from.root()
+        assert isinstance(module, astroid.nodes.Module)
+        module_name = module.relative_to_absolute_name(
+            import_from.modname, level=import_from.level
+        )
+
+    return "{}.{}".format(module_name, partial_basename)
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+def resolve_qualname(
+        ctx: astroid.nodes.NodeNG, 
+        basename: str) -> str:
+    """
+    Resolve a basename to get its fully qualified name.
+    :param ctx: The node representing the base name.
+    :param basename: The partial base name to resolve.
+    :returns: The fully resolved base name.
+    """
+    full_basename = basename
+
+    top_level_name = re.sub(r"\(.*\)", "", basename).split(".", 1)[0]
+    
+    # re.sub(r"\(.*\)", "", basename).split(".", 1)[0]
+    # Disable until pylint uses astroid 2.7
+    if isinstance(
+        ctx, astroid.nodes.node_classes.LookupMixIn  # pylint: disable=no-member
+    ):
+        lookup_node = ctx
+    else:
+        lookup_node = ctx.scope()
+
+    assigns = lookup_node.lookup(top_level_name)[1]
+
+    for assignment in assigns:
+        if isinstance(assignment, astroid.nodes.ImportFrom):
+            import_name = get_full_import_name(assignment, top_level_name)
+            full_basename = basename.replace(top_level_name, import_name, 1)
+            break
+        if isinstance(assignment, astroid.nodes.Import):
+            import_name = resolve_import_alias(top_level_name, assignment.names)
+            full_basename = basename.replace(top_level_name, import_name, 1)
+            break
+        if isinstance(assignment, astroid.nodes.ClassDef):
+            full_basename = assignment.qname()
+            break
+        if isinstance(assignment, astroid.nodes.AssignName):
+            full_basename = "{}.{}".format(assignment.scope().qname(), assignment.name)
+
+    full_basename = re.sub(r"\(.*\)", "()", full_basename)
+
+    if full_basename.startswith("builtins."):
+        return full_basename[len("builtins.") :]
+
+    if full_basename.startswith("__builtin__."):
+        return full_basename[len("__builtin__.") :]
+
+    return full_basename

--- a/astypes/_signature.py
+++ b/astypes/_signature.py
@@ -1,0 +1,234 @@
+"""
+Module containing code to transform an astroid FunctionDef into an inspect.Sgnature object.
+"""
+from functools import lru_cache
+import sys
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Optional, Iterator, Iterable, Tuple, Type, TypeVar, Union, cast
+import itertools
+import inspect
+import astroid.nodes
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+def _is_ellipsis(node:astroid.nodes.NodeNG) -> bool:
+    if sys.version_info < (3, 8):
+        return isinstance(node, astroid.Ellipsis)
+
+    return isinstance(node, astroid.Const) and node.value == Ellipsis #type:ignore[unreachable]
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+def _iter_args(args: List[astroid.nodes.AssignName], 
+               annotations: List[astroid.nodes.AssignName], 
+               defaults: List[astroid.nodes.AssignName]) -> Iterator[Tuple[str, 
+                                           Optional[astroid.nodes.NodeNG], 
+                                           Optional[astroid.nodes.NodeNG]]]:
+    
+    default_offset = len(args) - len(defaults)
+    packed = itertools.zip_longest(args, annotations)
+    for i, (arg, annotation) in enumerate(packed):
+        default = None
+        if defaults is not None and i >= default_offset:
+            if defaults[i - default_offset] is not None:
+                default = defaults[i - default_offset]
+        name = arg.name
+        yield (name, annotation, default)
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+def _merge_annotations(annotations: Iterable[Optional[astroid.nodes.NodeNG]], 
+                      comment_annotations: Iterable[Optional[astroid.nodes.NodeNG]]) -> Iterator[Optional[astroid.nodes.NodeNG]]:
+    for ann, comment_ann in itertools.zip_longest(annotations, comment_annotations):
+        if ann and not _is_ellipsis(ann):
+            yield ann
+        elif comment_ann and not _is_ellipsis(comment_ann):
+            yield comment_ann
+        else:
+            yield None
+
+class AstValue:
+    """
+    Wraps an AST value inside Signature instances. 
+
+    Formats values stored in AST expressions back to source code on calling repr().
+    Used for presenting default values of parameters and annotations. 
+    
+    :note: The default behaviour defers to `astroid.nodes.NodeNG.as_string`. 
+        This should be overriden if you want more formatting functions, like outputing HTML tags. 
+    """
+
+    def __init__(self, value: astroid.NodeNG):
+        self.value = value
+    def __repr__(self) -> str:
+        # Since astroid do not expose the typing information yet.
+        try:
+            return cast(str, self.value.as_string())
+        except AttributeError:
+            # Can raise AttributeError from node.as_string() as not all nodes have a visitor
+            return '<ERROR>'
+
+# for the sake of type annotations
+class AstParameter(inspect.Parameter):
+    default: AstValue
+    annotation: AstValue
+class AstSignature(inspect.Signature):
+    parameters: Mapping[str, inspect.Parameter]
+    return_annotation: AstValue
+
+@dataclass
+class SignatureBuilder:
+    """
+    Builds a signature, parameter by parameter, with customizable value and signature classes.
+    """
+    signature_class: Type['inspect.Signature'] = field(default=inspect.Signature)
+    value_class: Type['AstValue'] = field(default=AstValue)
+    _parameters: List[inspect.Parameter] = field(default_factory=list, init=False)
+    _return_annotation: Any = field(default=inspect.Signature.empty, init=False)
+
+    def add_param(self, name: str, 
+                  kind: inspect._ParameterKind, 
+                  default: Optional[Any]=None,
+                  annotation: Optional[Any]=None) -> None:
+        """
+        Add a new parameter to this signature.
+
+        None values will be replaces by Parameter.empty.
+        """
+        default_val = inspect.Parameter.empty if default is None else self.value_class(default)
+        annotation_val = inspect.Parameter.empty if annotation is None else self.value_class(annotation)
+        self._parameters.append(inspect.Parameter(name, kind, default=default_val, annotation=annotation_val))
+
+    def set_return_annotation(self, annotation: Optional[Any]) -> None:
+        """
+        Add a return annotation to this signature.
+        """
+        self._return_annotation = inspect.Signature.empty if annotation is None else self.value_class(annotation)
+
+    def get_signature(self) -> AstSignature:
+        """
+        Try to create the signature object from current parameters and return it.
+        :raises ValueError: If the function has invalid parameters.
+        """
+        return cast(AstSignature, 
+            self.signature_class(self._parameters, 
+            return_annotation=self._return_annotation))
+
+# The MIT License (MIT)
+# Copyright (c) 2015 Read the Docs, Inc
+_SignatureT = TypeVar('_SignatureT', bound=inspect.Signature)
+
+@lru_cache
+def signature(func: Union[astroid.nodes.AsyncFunctionDef, 
+                            astroid.nodes.FunctionDef], 
+              signature_class:Type[_SignatureT]=AstSignature, 
+              value_class:Type[AstValue]=AstValue) -> _SignatureT:
+    """
+    Builds `inspect.Signature` representing this function's parameters and return value.
+
+    :param func: An astroid FunctionDef.
+    :param signature_class: Customizable signature class to return.
+    :param value_class: Customizable value wrapper class to wrap AST values.
+
+    :raises ValueError: If the function has invalid parameters.
+    :note: does not support decorators that changes the signature. 
+    """
+    args_node: astroid.nodes.Arguments = func.args
+    sig_builder = SignatureBuilder(signature_class=signature_class, value_class=value_class)
+    positional_only_defaults: List[astroid.nodes.NodeNG] = []
+    positional_or_keyword_defaults = args_node.defaults
+    
+    if args_node.defaults:
+        args = args_node.args or []
+        positional_or_keyword_defaults = args_node.defaults[-len(args) :]
+        positional_only_defaults = args_node.defaults[
+            : len(args_node.defaults) - len(args)
+        ]
+
+    plain_annotations = args_node.annotations or ()
+    func_comment_annotations = func.type_comment_args or ()
+    comment_annotations = args_node.type_comment_posonlyargs
+    comment_annotations += args_node.type_comment_args or []
+    comment_annotations += args_node.type_comment_kwonlyargs
+    annotations = list(
+        _merge_annotations(
+            plain_annotations,
+            _merge_annotations(func_comment_annotations, comment_annotations),
+        )
+    )
+    annotation_offset = 0
+
+    if args_node.posonlyargs:
+        posonlyargs_annotations = args_node.posonlyargs_annotations
+        if not any(args_node.posonlyargs_annotations):
+            num_args = len(args_node.posonlyargs)
+            posonlyargs_annotations = annotations[
+                annotation_offset : annotation_offset + num_args
+            ]
+
+        for arg, annotation, default in _iter_args(
+            args_node.posonlyargs, posonlyargs_annotations, positional_only_defaults
+        ):
+            sig_builder.add_param(arg, kind=inspect.Parameter.POSITIONAL_ONLY, 
+                default=default, annotation=annotation)
+
+        if not any(args_node.posonlyargs_annotations):
+            annotation_offset += num_args
+
+    if args_node.args:
+        num_args = len(args_node.args)
+        for arg, annotation, default in _iter_args(
+            args_node.args,
+            annotations[annotation_offset : annotation_offset + num_args],
+            positional_or_keyword_defaults,
+        ):
+            sig_builder.add_param(arg, kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, 
+                default=default, annotation=annotation)
+
+        annotation_offset += num_args
+
+    if args_node.vararg:
+        annotation = None
+        if args_node.varargannotation:
+            annotation = args_node.varargannotation
+        elif len(annotations) > annotation_offset and annotations[annotation_offset]:
+            annotation = annotations[annotation_offset]
+            annotation_offset += 1
+        sig_builder.add_param(args_node.vararg, 
+                kind=inspect.Parameter.VAR_POSITIONAL,
+                default=None,
+                annotation=annotation)
+
+    if args_node.kwonlyargs:
+        kwonlyargs_annotations = args_node.kwonlyargs_annotations
+        if not any(args_node.kwonlyargs_annotations):
+            num_args = len(args_node.kwonlyargs)
+            kwonlyargs_annotations = annotations[
+                annotation_offset : annotation_offset + num_args
+            ]
+
+        for arg, annotation, default in _iter_args(
+            args_node.kwonlyargs,
+            kwonlyargs_annotations,
+            args_node.kw_defaults,
+        ):
+            sig_builder.add_param(arg, 
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=default, annotation=annotation)
+            
+        if not any(args_node.kwonlyargs_annotations):
+            annotation_offset += num_args
+
+    if args_node.kwarg:
+        annotation = None
+        if args_node.kwargannotation:
+            annotation = args_node.kwargannotation
+        elif len(annotations) > annotation_offset and annotations[annotation_offset]:
+            annotation = annotations[annotation_offset]
+            annotation_offset += 1
+        sig_builder.add_param(args_node.kwarg, 
+                kind=inspect.Parameter.VAR_KEYWORD,
+                default=None, annotation=annotation)
+    
+    sig_builder.set_return_annotation(func.returns)
+    return sig_builder.get_signature()

--- a/tests/test_ann_to_type.py
+++ b/tests/test_ann_to_type.py
@@ -2,6 +2,7 @@ import pytest
 
 import astroid
 from astypes._ann_to_type import get_annotation
+from astypes._handlers import get_type
 
 @pytest.mark.parametrize(
         ("source", "expected"), 
@@ -18,6 +19,9 @@ from astypes._ann_to_type import get_annotation
 def test_annoation_to_type(source:str, expected:str) -> None:
     mod = astroid.parse(source)
     type_annotation = get_annotation(mod.body[-1].annotation)
+    type_annotation_method2 = get_type(mod.getattr('var')[-1])
+    
+    assert type_annotation == type_annotation_method2
     assert not type_annotation.unknown
     imports = '\n'.join(type_annotation.imports)
     annotation, imports_contains = expected

--- a/tests/test_ann_to_type.py
+++ b/tests/test_ann_to_type.py
@@ -1,0 +1,33 @@
+import pytest
+
+import astroid
+from astypes._ann_to_type import get_annotation
+
+@pytest.mark.parametrize(
+        ("source", "expected"), 
+        [("var: typing.Generic[T]", ["Generic[T]","typing"]), 
+        ("var: typing.Generic[T, _KV]", ["Generic[T, _KV]","typing"]),
+        ("from typing import Generic\nvar: Generic[T]", ["Generic[T]","typing"]),
+        ("from mod import _model as m\nfrom typing import Optional\nvar: m.TreeRoot[Optional[T]]", ["TreeRoot[Optional[T]]","typing,mod._model"]),
+        ("var: dict[str, str]", ["dict[str, str]",'']),
+        ("import typing as t\nvar: t.Union[dict[str, str], dict[str, int]]", ["dict[str, str] | dict[str, int]",'typing']),
+        ("import typing as t\nvar: t.Literal[True, False]", ["Literal[True, False]",'typing']),
+        ("import typing as t\nvar: t.Literal['string']", ["Literal['string']",'typing']),
+        ("import typing as t\nvar: dict[t.Type, t.Callable[[t.Any], t.Type]]", ["dict[Type, Callable[Any, Type]]",'typing'])]
+    )
+def test_annoation_to_type(source:str, expected:str) -> None:
+    mod = astroid.parse(source)
+    type_annotation = get_annotation(mod.body[-1].annotation)
+    assert not type_annotation.unknown
+    imports = '\n'.join(type_annotation.imports)
+    annotation, imports_contains = expected
+    if annotation.startswith('Union'):
+        assert type_annotation.is_union
+    if annotation.startswith('Literal'):
+        assert type_annotation.is_literal
+    for i in imports_contains.split(','):
+        assert i in imports, f"{i!r} not in {imports}"
+    assert type_annotation.annotation == annotation
+    
+    # smoke test
+    astroid.parse(type_annotation.annotation)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,7 +1,8 @@
 from typing import List
 import astroid
 import pytest
-from astypes import get_type, Type, merge_types
+from astypes import get_type, Type
+from astypes._type import merge_types
 
 
 @pytest.mark.parametrize('expr, type', [

--- a/tests/test_resolve_qualname.py
+++ b/tests/test_resolve_qualname.py
@@ -1,0 +1,95 @@
+
+from typing import Iterator, Tuple
+
+import astroid
+
+import pytest
+
+from astypes._resolve_qualname import resolve_qualname
+
+# from sphinx-autoapi
+
+def generate_module_names() -> Iterator[str]:
+    for i in range(1, 5):
+        yield ".".join("module{}".format(j) for j in range(i))
+
+    yield "package.repeat.repeat"
+
+
+def imported_basename_cases() -> Iterator[Tuple[str, str, str]]:
+    for module_name in generate_module_names():
+        import_ = "import {}".format(module_name)
+        basename = "{}.ImportedClass".format(module_name)
+        expected = basename
+
+        yield (import_, basename, expected)
+
+        import_ = "import {} as aliased".format(module_name)
+        basename = "aliased.ImportedClass"
+
+        yield (import_, basename, expected)
+
+        if "." in module_name:
+            from_name, attribute = module_name.rsplit(".", 1)
+            import_ = "from {} import {}".format(from_name, attribute)
+            basename = "{}.ImportedClass".format(attribute)
+            yield (import_, basename, expected)
+
+            import_ += " as aliased"
+            basename = "aliased.ImportedClass"
+            yield (import_, basename, expected)
+
+        import_ = "from {} import ImportedClass".format(module_name)
+        basename = "ImportedClass"
+        yield (import_, basename, expected)
+
+        import_ = "from {} import ImportedClass as AliasedClass".format(module_name)
+        basename = "AliasedClass"
+        yield (import_, basename, expected)
+
+
+def generate_args() -> Iterator[str]:
+    for i in range(5):
+        yield ", ".join("arg{}".format(j) for j in range(i))
+
+
+def imported_call_cases() -> Iterator[Tuple[str, str, str]]:
+    for args in generate_args():
+        for import_, basename, expected in imported_basename_cases():
+            basename += "({})".format(args)
+            expected += "()"
+            yield import_, basename, expected
+
+
+class TestAstroidUtilsAndExpandName:
+
+    @pytest.mark.parametrize(
+        ("import_", "basename", "expected"), list(imported_basename_cases())
+    )
+    def test_can_get_full_imported_basename(self,
+            import_:str, basename:str, expected:str) -> None:
+        source = """
+        {}
+        class ThisClass({}): #@
+            pass
+        """.format(
+            import_, basename
+        )
+        node = astroid.extract_node(source)
+        basenames = resolve_qualname(node, node.basenames[0])
+        assert basenames == expected
+
+    @pytest.mark.parametrize(
+        ("import_", "basename", "expected"), list(imported_call_cases())
+    )
+    def test_can_get_full_function_basename(self, import_:str, basename:str, expected:str) -> None:
+        source = """
+        {}
+        class ThisClass({}): #@
+            pass
+        """.format(
+            import_, basename
+        )
+        node = astroid.extract_node(source)
+        basenames = resolve_qualname(node, node.basenames[0])
+        assert basenames == expected

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,72 @@
+import sys
+import pytest
+import astroid
+
+from inspect import Signature
+from astypes._signature import signature
+
+posonlyargs = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")
+typecomment = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python 3.8")
+
+@pytest.mark.parametrize('sig', (
+    '()',
+    '(*, a, b=None)',
+    '(*, a=(), b)',
+    '(a, b=3, *c, **kw)',
+    '(f=True)',
+    '(x=0.1, y=-2)',
+    "(s='theory', t=\"con'text\")",
+    ))
+def test_function_signature(sig: str) -> None:
+    """
+    A round trip from source to inspect.Signature and back produces
+    the original text.
+    """
+    mod = astroid.parse(f'def f{sig}: ...')
+    func = mod['f']
+    assert isinstance(func, astroid.FunctionDef)
+    sig_instance = signature(func)
+    assert isinstance(sig_instance, Signature)
+    text = str(sig_instance)
+    assert text == sig
+
+@posonlyargs
+@pytest.mark.parametrize('sig', (
+    '(x, y, /)',
+    '(x, y=0, /)',
+    '(x, y, /, z, w)',
+    '(x, y, /, z, w=42)',
+    '(x, y, /, z=0, w=0)',
+    '(x, y=3, /, z=5, w=7)',
+    '(x, /, *v, a=1, b=2)',
+    '(x, /, *, a=1, b=2, **kwargs)',
+    ))
+def test_function_signature_posonly(sig: str) -> None:
+    test_function_signature(sig)
+
+@pytest.mark.parametrize('sig', (
+    '(*, a: int | None, b=...)',
+    '(*, a: \'int | None\', b: Literal[...] = None)',
+    '(a: str, b: Callable[..., Any] = 3, *c: int, **kw: Any) -> None',
+    '(f: Literal[False, True] = True) -> bytes | str',
+    "(s: Literal['theory'] = 'theory', t: Literal[\"con'text\"] = \"con'text\")",
+    ))
+def test_function_signature_types(sig: str) -> None:
+    test_function_signature(sig)
+
+@pytest.mark.parametrize('sig', (
+    '(a, a)',
+    ))
+def test_function_badsig(sig: str) -> None:
+    """When a function has an invalid signature, an error is logged and
+    the empty signature is returned.
+    Note that most bad signatures lead to a SyntaxError, which we cannot
+    recover from. This test checks what happens if the AST can be produced
+    but inspect.Signature() rejects the parsed parameters.
+    """
+
+    mod = astroid.parse(f'def f{sig}: ...')
+    func = mod['f']
+    assert isinstance(func, astroid.FunctionDef)
+    with pytest.raises(ValueError):
+        signature(func)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist =
+    test
+isolated_build = True
+
+[testenv:test]
+description = Run tests
+extras =
+    test
+
+commands = 
+    pytest -vv {posargs: tests}


### PR DESCRIPTION
This includes code to fetch the types of variables coming from a function arguments or from another assignment. 

```python
def minimum(lst:list[int])-> int:
    _list = lst # <- this value has type list[int], obviously.
```

I've included an alternative implementation of `conv_node_to_type` that work only with astroid nodes but it produce a more complete `Type` instance, see `_ann_to_type.py`. There is also a utility function that get the `Signature` from a `FunctionDef`, which is very easy to work with, see `_signature.py`.  

Tell me what you think, I would be very glad if there changes could be merged. Thanks. 

