### PR TITLE
Infer types for variables annotated as a function arg

### DIFF
--- a/astypes/_ass.py
+++ b/astypes/_ass.py
@@ -18,3 +18,5 @@ class Ass(Enum):
     CAMEL_CASE_IS_TYPE = 'camel-case-is-type'
     # assume that built-in types and functions aren't shadowed
     NO_SHADOWING = 'camel-case-is-type'
+    # assume that if variable is once annotated its type never changes in the scope
+    NO_REDEF = 'camel-case-is-type'

--- a/astypes/_handlers.py
+++ b/astypes/_handlers.py
@@ -11,8 +11,8 @@ import typeshed_client
 
 from ._ass import Ass
 from ._helpers import (
-    conv_node_to_type, get_ret_type_of_fun, infer, is_camel, qname_to_type,
-    get_parent_function,
+    conv_node_to_type, get_parent_function, get_ret_type_of_fun, infer,
+    is_camel, qname_to_type,
 )
 from ._type import Type
 

--- a/astypes/_helpers.py
+++ b/astypes/_helpers.py
@@ -75,9 +75,24 @@ def conv_node_to_type(
         logger.debug('no return type annotation for called function def')
         return None
 
-    # for generics, keep it generic
+    # for generics, try to convert parameters too.
     if isinstance(node, (ast.Subscript, astroid.Subscript)):
-        return conv_node_to_type(mod_name, node.value)
+        base_type = conv_node_to_type(mod_name, node.value)
+        if base_type is None:
+            return None
+        args: list[Type] = []
+        if isinstance(node.slice, (ast.Tuple, astroid.Tuple)):
+            for arg_node in node.slice.elts:
+                arg_type = conv_node_to_type(mod_name, arg_node)
+                if arg_type is None:
+                    return base_type
+                args.append(arg_type)
+        else:
+            arg_type = conv_node_to_type(mod_name, node.slice)
+            if arg_type is None:
+                return base_type
+            args.append(arg_type)
+        return base_type.add_args(args)
 
     # for regular name, check if it is a typing primitive or a built-in
     name: str | None = None

--- a/astypes/_helpers.py
+++ b/astypes/_helpers.py
@@ -66,7 +66,7 @@ def conv_node_to_type(
     mod_name: str,
     node: ast.AST | astroid.NodeNG | None,
 ) -> Type | None:
-    """Resolve ast node representing a type annotation into a type.
+    """Resolve AST node representing a type annotation into a type.
     """
     import builtins
     import typing
@@ -94,4 +94,13 @@ def conv_node_to_type(
         return None
 
     logger.debug('cannot resolve return AST node into a known type')
+    return None
+
+
+def get_parent_function(node: astroid.NodeNG) -> astroid.FunctionDef | None:
+    """Find the node of the function that contains the given node.
+    """
+    for parent in node.node_ancestors():
+        if isinstance(parent, astroid.FunctionDef):
+            return parent
     return None

--- a/astypes/_type.py
+++ b/astypes/_type.py
@@ -168,6 +168,11 @@ class Type:
         """
         return replace(self, _ass=self._ass | {ass})
 
+    def add_args(self, args: list[Type]) -> Type:
+        """Get a copy of the Type with the given args added in the list of args.
+        """
+        return replace(self, _args=self._args + args)
+
     def supertype_of(self, other: Type) -> bool:
         if self.name == 'float' and other.name == 'int':
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ addopts = [
     "--cov=astypes",
     "--cov-report=html",
     "--cov-report=term-missing:skip-covered",
-    "--cov-fail-under=91",
+    "--cov-fail-under=93",
 ]
 
 [tool.coverage.report]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -138,13 +138,21 @@ def test_astroid_inference(setup, expr, type):
     ('*, a: int', 'int'),
     ('a: int, /', 'int'),
     ('a: list', 'list'),
+
+    # *args and **kwargs
     ('*a: int', 'tuple[int]'),
     ('*a: garbage', 'tuple'),
     ('*a', 'tuple'),
     ('**a: int', 'dict[str, int]'),
     ('**a: garbage', 'dict[str, Any]'),
     ('**a', 'dict[str, Any]'),
-    # ('a: list[str]', 'list[str]'),
+
+    # parametrized generics
+    ('a: list[str]', 'list[str]'),
+    ('a: list[garbage]', 'list'),
+    ('a: dict[str, int]', 'dict[str, int]'),
+    ('a: tuple[str, int, float]', 'tuple[str, int, float]'),
+    ('a: tuple[str, garbage]', 'tuple'),
 ])
 def test_infer_type_from_signature(sig, type):
     given = f"""
@@ -166,6 +174,7 @@ def test_infer_type_from_signature(sig, type):
     'b: int',
     'a',
     'a: garbage',
+    'a: garbage[int]',
 ])
 def test_cannot_infer_type_from_signature(sig):
     given = f"""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -123,9 +123,23 @@ def test_cannot_infer_expr(expr):
     ('def g(x): return 0',          'g(x)',         'int'),
     ('def g(x) -> int: return x',   'g(x)',         'int'),
 ])
-def test_astroid_inference(tmp_path, setup, expr, type):
+def test_astroid_inference(setup, expr, type):
     stmt = astroid.parse(f'{setup}\n{expr}').body[-1]
     assert isinstance(stmt, astroid.Expr)
     t = get_type(stmt.value)
     assert t is not None
     assert t.annotation == type
+
+
+def test_infer_type_from_signature():
+    given = """
+        def f(a: list[str]):
+            return a
+    """
+    func = astroid.parse(given).body[-1]
+    assert isinstance(func, astroid.FunctionDef)
+    stmt = func.body[-1]
+    assert isinstance(stmt, astroid.Return)
+    t = get_type(stmt)
+    assert t is not None
+    assert t.annotation == 'list'


### PR DESCRIPTION
1. If the target variable is a simple name, it is defined as a function argument, and that argument is annotated, use this annotation as the variable type.
2. When converting parametrized generics from node to type, preserve types of parameters whenever possible.